### PR TITLE
Fix opening URLs after wslpath behavior change.

### DIFF
--- a/wsl_open.sh
+++ b/wsl_open.sh
@@ -44,7 +44,7 @@ fi
 
 # Open file with https://github.com/wslutilities/wslu.
 if [ -e "$*" ]; then
-    # Is file and it exists.
+    # Path exists locally.
     wslview "$(wslpath -w "$*" 2>/dev/null)"
 else
     # Might be link.

--- a/wsl_open.sh
+++ b/wsl_open.sh
@@ -42,11 +42,11 @@ if [ "$REVEAL" = true ]; then
     exit 0
 fi
 
-# Open file/link with https://github.com/wslutilities/wslu.
-if windows_path="$(wslpath -w "$*" 2>/dev/null)"; then
+# Open file with https://github.com/wslutilities/wslu.
+if [ -e "$*" ]; then
     # Is file and it exists.
-    wslview "$windows_path"
+    wslview "$(wslpath -w "$*" 2>/dev/null)"
 else
-    # Might be link, wslview will fail if it's a file/dir that doesn't exist.
+    # Might be link.
     wslview "$*"
 fi


### PR DESCRIPTION
In latest versions of wslpath it no longer exits 1 if a file doesn't exist. It goes ahead and apparently does path delimiter replacement and exits 0.

Moving "if file exists" logic into this script instead of relying on wslpath.